### PR TITLE
Fix case sensitive path

### DIFF
--- a/sibgif.js
+++ b/sibgif.js
@@ -76,7 +76,7 @@
 }(this, function () {
     if (typeof exports === 'object') {
         var Stream = require('./Stream.js');
-        var parseGIF = require('./parseGIF.js');
+        var parseGIF = require('./parseGif.js');
     }
     var SuperGif = function ( opts ) {
         var options = {


### PR DESCRIPTION
PR to fix this error while using sibgif with react+webpack :

```
Error in ./~/sibgif/sibgif.js
Module not found: [CaseSensitivePathsPlugin] `.../client/node_modules/sibgif/parseGif.js` does not match the corresponding path on disk `parseGIF.js`.
```

